### PR TITLE
Ordinal Formatter Web bug fixes

### DIFF
--- a/lib/ordinal_formatter_web.dart
+++ b/lib/ordinal_formatter_web.dart
@@ -21,19 +21,29 @@ class OrdinalFormatterWeb extends OrdinalFormatterPlatform {
   @override
   Future<String?> format(int number, [String? localeCode]) async {
     //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules
+    final locale = localeCode ?? defaultLocale;
+    final ordinalRules = getOrdinalRules(number, locale);
+    final suffix = ordinalSuffixes[locale]?[ordinalRules];
+    if (suffix == null) {
+      return null;
+    }
+    return '$number$suffix';
+  }
+
+  String? getOrdinalRules(int number, [String? localeCode]) {
     final ordinalFormatter = js.JsObject(
       js.context['Intl']['PluralRules'],
       [
         localeCode ?? defaultLocale,
-        {'type': 'ordinal'},
+        js.JsObject.jsify({'type': 'ordinal'}),
       ],
     );
 
     final ordinalRules = ordinalFormatter.callMethod('select', [number]);
-    //
-    final suffix = ordinalSuffixes[localeCode ?? defaultLocale]?[ordinalRules];
-    return '$number$suffix';
+
+    return ordinalRules;
   }
+  //
 
   // Localized ordinal documentation can be found at-
   // https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html

--- a/lib/ordinal_formatter_web.dart
+++ b/lib/ordinal_formatter_web.dart
@@ -43,7 +43,6 @@ class OrdinalFormatterWeb extends OrdinalFormatterPlatform {
 
     return ordinalRules;
   }
-  //
 
   // Localized ordinal documentation can be found at-
   // https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html


### PR DESCRIPTION
- Fixed error where js was using cardinal instead of ordinal type. The "type" is now being properly encoded.
- Separated ordinal rule fetcher into own function.
- Returning null if suffix is null (previously return would be string "null").