### PR TITLE
Add namespace to be compatible with flutter 3.29.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.example.ordinal_formatter'
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
This PR adds a namespace configuration to the build.gradle file to ensure compatibility with Flutter 3.29.3. 
